### PR TITLE
Add settings tab with dark mode toggle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'screens/today_screen.dart';
 import 'screens/history_screen.dart';
 import 'screens/trends_screen.dart';
 import 'screens/setup_screen.dart';
+import 'screens/settings_screen.dart';
 
 void main() {
   runApp(
@@ -24,12 +25,22 @@ class DialysisApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final settings = context.watch<SettingsStore>();
+
     return MaterialApp(
       title: 'Dialysis Tracker',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
         useMaterial3: true,
       ),
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.teal,
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      ),
+      themeMode: settings.darkMode ? ThemeMode.dark : ThemeMode.light,
       home: const _Gate(),
     );
   }
@@ -67,6 +78,7 @@ class _RootState extends State<_Root> {
     TodayScreen(),
     HistoryScreen(),
     TrendsScreen(),
+    SettingsScreen(),
   ];
 
   @override
@@ -80,6 +92,7 @@ class _RootState extends State<_Root> {
           NavigationDestination(icon: Icon(Icons.home), label: 'Today'),
           NavigationDestination(icon: Icon(Icons.list_alt), label: 'History'),
           NavigationDestination(icon: Icon(Icons.show_chart), label: 'Trends'),
+          NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
         ],
       ),
     );

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../state/settings_store.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = context.watch<SettingsStore>();
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        SwitchListTile(
+          title: const Text('Dark Mode'),
+          value: settings.darkMode,
+          onChanged: (value) => context.read<SettingsStore>().setDarkMode(value),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/state/settings_store.dart
+++ b/lib/state/settings_store.dart
@@ -6,14 +6,17 @@ import '../models/profile.dart';
 class SettingsStore extends ChangeNotifier {
   static const _kOnboarded = 'onboarded';
   static const _kProfile = 'profile';
+  static const _kDarkMode = 'darkMode';
 
   bool _loaded = false;          // 👈 NEW
   bool _onboarded = false;
   Profile? _profile;
+  bool _darkMode = false;
 
   bool get loaded => _loaded;    // 👈 NEW
   bool get onboarded => _onboarded;
   Profile? get profile => _profile;
+  bool get darkMode => _darkMode;
 
   Future<void> load() async {
     final sp = await SharedPreferences.getInstance();
@@ -22,6 +25,7 @@ class SettingsStore extends ChangeNotifier {
     if (p != null) {
       _profile = Profile.fromJson(jsonDecode(p));
     }
+    _darkMode = sp.getBool(_kDarkMode) ?? false;
     _loaded = true;              // 👈 mark done
     notifyListeners();
   }
@@ -33,6 +37,13 @@ class SettingsStore extends ChangeNotifier {
     _profile = p;
     _onboarded = true;
     _loaded = true;
+    notifyListeners();
+  }
+
+  Future<void> setDarkMode(bool enabled) async {
+    final sp = await SharedPreferences.getInstance();
+    await sp.setBool(_kDarkMode, enabled);
+    _darkMode = enabled;
     notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated settings tab to the bottom navigation
- persist a dark mode preference and apply it to the app theme
- surface a switch in the settings tab to toggle dark mode

## Testing
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9afd5e2bc832bb476989c75035dbc