### PR TITLE
Revamp setup flow for user profile

### DIFF
--- a/lib/models/profile.dart
+++ b/lib/models/profile.dart
@@ -1,24 +1,39 @@
-class Profile {
-  final String name;
-  final List<int> dialysisWeekdays; // 1=Mon … 7=Sun (DateTime.monday..sunday)
-  final String units; // 'kg' for now; future: lbs, etc.
+enum WeightUnit { kg, lb }
 
-  const Profile({
-    required this.name,
-    required this.dialysisWeekdays,
-    this.units = 'kg',
-  });
+extension WeightUnitLabel on WeightUnit {
+  String get storageKey => this == WeightUnit.lb ? 'lb' : 'kg';
 
-  Map<String, dynamic> toJson() => {
-        'name': name,
-        'days': dialysisWeekdays,
-        'units': units,
-      };
-
-  factory Profile.fromJson(Map<String, dynamic> j) => Profile(
-        name: j['name'] ?? '',
-        dialysisWeekdays: (j['days'] as List).cast<int>(),
-        units: j['units'] ?? 'kg',
-      );
+  String get displayLabel => this == WeightUnit.lb ? 'lbs' : 'kg';
 }
 
+WeightUnit weightUnitFromStorage(String? value) {
+  return value == 'lb' ? WeightUnit.lb : WeightUnit.kg;
+}
+
+class UserProfile {
+  final String name;
+  final String? photoPath;
+  final double startWeight;
+  final WeightUnit unit;
+
+  const UserProfile({
+    required this.name,
+    required this.startWeight,
+    required this.unit,
+    this.photoPath,
+  });
+
+  UserProfile copyWith({
+    String? name,
+    String? photoPath,
+    double? startWeight,
+    WeightUnit? unit,
+  }) {
+    return UserProfile(
+      name: name ?? this.name,
+      photoPath: photoPath ?? this.photoPath,
+      startWeight: startWeight ?? this.startWeight,
+      unit: unit ?? this.unit,
+    );
+  }
+}

--- a/lib/screens/setup_screen.dart
+++ b/lib/screens/setup_screen.dart
@@ -1,5 +1,9 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
+
 import '../models/profile.dart';
 import '../state/settings_store.dart';
 
@@ -11,94 +15,274 @@ class SetupScreen extends StatefulWidget {
 }
 
 class _SetupScreenState extends State<SetupScreen> {
-  final _form = GlobalKey<FormState>();
-  final _name = TextEditingController();
-  final Set<int> _days = {}; // DateTime.monday..sunday
+  final _formKey = GlobalKey<FormState>();
+  final _nameCtrl = TextEditingController();
+  final _weightCtrl = TextEditingController();
+
+  WeightUnit _unit = WeightUnit.kg;
+  String? _photoPath;
+  bool _isValid = false;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameCtrl.addListener(_handleFormChange);
+    _weightCtrl.addListener(_handleFormChange);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final profile = context.read<SettingsStore>().profile;
+      if (profile != null) {
+        _nameCtrl.text = profile.name;
+        _weightCtrl.text = _formatWeight(profile.startWeight);
+        setState(() {
+          _unit = profile.unit;
+          _photoPath = profile.photoPath;
+        });
+      }
+      _updateValidity();
+    });
+  }
 
   @override
   void dispose() {
-    _name.dispose();
+    _nameCtrl.removeListener(_handleFormChange);
+    _weightCtrl.removeListener(_handleFormChange);
+    _nameCtrl.dispose();
+    _weightCtrl.dispose();
     super.dispose();
   }
 
-  void _toggle(int weekday) {
+  void _handleFormChange() {
+    _updateValidity();
+  }
+
+  void _updateValidity() {
+    final name = _nameCtrl.text.trim();
+    final weightText = _weightCtrl.text.trim();
+    final weight = double.tryParse(weightText);
+    final valid = name.isNotEmpty && weight != null && weight > 0;
+    if (_isValid != valid) {
+      setState(() {
+        _isValid = valid;
+      });
+    }
+  }
+
+  String _formatWeight(double weight) {
+    if (weight % 1 == 0) {
+      return weight.toStringAsFixed(0);
+    }
+    return weight.toString();
+  }
+
+  Future<void> _pickPhoto() async {
+    final theme = Theme.of(context);
+    final source = await showModalBottomSheet<ImageSource>(
+      context: context,
+      backgroundColor: theme.colorScheme.surface,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.photo_camera),
+                title: const Text('Camera'),
+                onTap: () => Navigator.of(sheetContext).pop(ImageSource.camera),
+              ),
+              ListTile(
+                leading: const Icon(Icons.photo_library),
+                title: const Text('Gallery'),
+                onTap: () => Navigator.of(sheetContext).pop(ImageSource.gallery),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    if (source == null) return;
+
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(
+      source: source,
+      maxWidth: 1024,
+      imageQuality: 85,
+    );
+    if (picked != null) {
+      setState(() {
+        _photoPath = picked.path;
+      });
+    }
+  }
+
+  Future<void> _saveAndContinue() async {
+    if (_saving) return;
+    FocusScope.of(context).unfocus();
+    final isValid = _formKey.currentState?.validate() ?? false;
+    if (!isValid) {
+      _updateValidity();
+      return;
+    }
+
     setState(() {
-      if (_days.contains(weekday)) {
-        _days.remove(weekday);
-      } else {
-        _days.add(weekday);
-      }
+      _saving = true;
+    });
+
+    final name = _nameCtrl.text.trim();
+    final startWeight = double.parse(_weightCtrl.text.trim());
+    final profile = UserProfile(
+      name: name,
+      photoPath: _photoPath,
+      startWeight: startWeight,
+      unit: _unit,
+    );
+
+    await context.read<SettingsStore>().saveProfile(profile);
+
+    if (!mounted) return;
+    setState(() {
+      _saving = false;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    const wdays = <int, String>{
-      DateTime.monday: 'Mon',
-      DateTime.tuesday: 'Tue',
-      DateTime.wednesday: 'Wed',
-      DateTime.thursday: 'Thu',
-      DateTime.friday: 'Fri',
-      DateTime.saturday: 'Sat',
-      DateTime.sunday: 'Sun',
-    };
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final avatarImage = _photoPath != null ? FileImage(File(_photoPath!)) : null;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Welcome')),
-      body: Form(
-        key: _form,
-        child: ListView(
+      appBar: AppBar(title: const Text('Setup')),
+      body: SafeArea(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
-          children: [
-            const Text(
-              "Let's set up your profile",
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          child: Form(
+            key: _formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: Column(
+                    children: [
+                      Stack(
+                        alignment: Alignment.bottomRight,
+                        children: [
+                          CircleAvatar(
+                            radius: 56,
+                            backgroundColor: colorScheme.surfaceVariant,
+                            backgroundImage: avatarImage,
+                            child: avatarImage == null
+                                ? Icon(
+                                    Icons.person,
+                                    size: 48,
+                                    color: colorScheme.onSurfaceVariant,
+                                  )
+                                : null,
+                          ),
+                          Material(
+                            shape: const CircleBorder(),
+                            color: colorScheme.primary,
+                            child: IconButton(
+                              icon: const Icon(Icons.camera_alt),
+                              color: colorScheme.onPrimary,
+                              tooltip: _photoPath == null
+                                  ? 'Add photo'
+                                  : 'Change photo',
+                              onPressed: _pickPhoto,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      TextButton(
+                        onPressed: _pickPhoto,
+                        child: Text(_photoPath == null ? 'Add photo' : 'Change photo'),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 24),
+                TextFormField(
+                  controller: _nameCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Name *',
+                  ),
+                  textInputAction: TextInputAction.next,
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter your name';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _weightCtrl,
+                  decoration: InputDecoration(
+                    labelText: 'Starting weight (${_unit.displayLabel}) *',
+                  ),
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                  validator: (value) {
+                    final text = value?.trim() ?? '';
+                    if (text.isEmpty) {
+                      return 'Enter your starting weight';
+                    }
+                    final weight = double.tryParse(text);
+                    if (weight == null || weight <= 0) {
+                      return 'Enter a valid number';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      ChoiceChip(
+                        label: const Text('kg'),
+                        selected: _unit == WeightUnit.kg,
+                        onSelected: (selected) {
+                          if (selected) {
+                            setState(() {
+                              _unit = WeightUnit.kg;
+                            });
+                          }
+                        },
+                      ),
+                      ChoiceChip(
+                        label: const Text('lbs'),
+                        selected: _unit == WeightUnit.lb,
+                        onSelected: (selected) {
+                          if (selected) {
+                            setState(() {
+                              _unit = WeightUnit.lb;
+                            });
+                          }
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 24),
+                FilledButton(
+                  onPressed: _isValid && !_saving ? _saveAndContinue : null,
+                  child: _saving
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Save & Continue'),
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            TextFormField(
-              controller: _name,
-              decoration: const InputDecoration(
-                labelText: 'Your name (optional)',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: 16),
-            const Text('Which days are your dialysis days?'),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 8,
-              children: wdays.entries.map((e) {
-                final selected = _days.contains(e.key);
-                return FilterChip(
-                  selected: selected,
-                  label: Text(e.value),
-                  onSelected: (_) => _toggle(e.key),
-                );
-              }).toList(),
-            ),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: () async {
-                if (_days.isEmpty) {
-                  ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                      content: Text('Pick at least one dialysis day')));
-                  return;
-                }
-                final profile = Profile(
-                  name: _name.text.trim(),
-                  dialysisWeekdays: _days.toList()..sort(),
-                );
-                await context.read<SettingsStore>().saveProfile(profile);
-              },
-              child: const Padding(
-                padding: EdgeInsets.all(14.0),
-                child: Text('Continue'),
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );
   }
 }
-

--- a/lib/screens/widgets/calendar_header.dart
+++ b/lib/screens/widgets/calendar_header.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
+
 import '../../state/session_store.dart';
 import '../../state/settings_store.dart';
 
@@ -17,17 +18,13 @@ class _CalendarHeaderState extends State<CalendarHeader> {
   @override
   Widget build(BuildContext context) {
     final sessions = context.watch<SessionStore>().sessions;
-    final profile = context.watch<SettingsStore>().profile;
+    context.watch<SettingsStore>();
 
-    // Sessions per day
     final Map<DateTime, int> sessionCount = {};
     for (final s in sessions) {
       final d = DateTime(s.date.year, s.date.month, s.date.day);
       sessionCount[d] = (sessionCount[d] ?? 0) + 1;
     }
-
-    bool isDialysisWeekday(DateTime d) =>
-        profile?.dialysisWeekdays.contains(d.weekday) ?? false;
 
     return TableCalendar(
       firstDay: DateTime.utc(2022, 1, 1),
@@ -40,10 +37,8 @@ class _CalendarHeaderState extends State<CalendarHeader> {
         markerBuilder: (context, day, events) {
           final dd = DateTime(day.year, day.month, day.day);
           final hasSession = sessionCount.containsKey(dd);
-          final isDialysisDay = isDialysisWeekday(day);
-          if (!hasSession && !isDialysisDay) return null;
+          if (!hasSession) return null;
 
-          // session dot = filled; dialysis day (no session) = hollow
           return Align(
             alignment: Alignment.bottomCenter,
             child: Padding(
@@ -51,7 +46,7 @@ class _CalendarHeaderState extends State<CalendarHeader> {
               child: Icon(
                 Icons.circle,
                 size: 6,
-                color: hasSession ? Colors.teal : Colors.teal.withOpacity(0.35),
+                color: Theme.of(context).colorScheme.primary,
               ),
             ),
           );
@@ -61,4 +56,3 @@ class _CalendarHeaderState extends State<CalendarHeader> {
     );
   }
 }
-

--- a/lib/state/settings_store.dart
+++ b/lib/state/settings_store.dart
@@ -1,39 +1,57 @@
-import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/profile.dart';
 
 class SettingsStore extends ChangeNotifier {
-  static const _kOnboarded = 'onboarded';
-  static const _kProfile = 'profile';
+  static const _kName = 'profile.name';
+  static const _kPhotoPath = 'profile.photoPath';
+  static const _kStartWeight = 'profile.startWeight';
+  static const _kUnit = 'profile.unit';
 
-  bool _loaded = false;          // 👈 NEW
-  bool _onboarded = false;
-  Profile? _profile;
+  bool _loaded = false;
+  UserProfile? _profile;
 
-  bool get loaded => _loaded;    // 👈 NEW
-  bool get onboarded => _onboarded;
-  Profile? get profile => _profile;
+  bool get loaded => _loaded;
+  bool get onboarded => _profile != null;
+  UserProfile? get profile => _profile;
 
   Future<void> load() async {
     final sp = await SharedPreferences.getInstance();
-    _onboarded = sp.getBool(_kOnboarded) ?? false;
-    final p = sp.getString(_kProfile);
-    if (p != null) {
-      _profile = Profile.fromJson(jsonDecode(p));
+    final name = sp.getString(_kName)?.trim();
+    final startWeightRaw = sp.getString(_kStartWeight);
+    final unitRaw = sp.getString(_kUnit);
+    final photoPath = sp.getString(_kPhotoPath);
+    final startWeight = startWeightRaw != null ? double.tryParse(startWeightRaw) : null;
+
+    if (name != null && name.isNotEmpty && startWeight != null && startWeight > 0) {
+      _profile = UserProfile(
+        name: name,
+        photoPath: photoPath?.isNotEmpty == true ? photoPath : null,
+        startWeight: startWeight,
+        unit: weightUnitFromStorage(unitRaw),
+      );
+    } else {
+      _profile = null;
     }
-    _loaded = true;              // 👈 mark done
+
+    _loaded = true;
     notifyListeners();
   }
 
-  Future<void> saveProfile(Profile p) async {
+  Future<void> saveProfile(UserProfile profile) async {
     final sp = await SharedPreferences.getInstance();
-    await sp.setString(_kProfile, jsonEncode(p.toJson()));
-    await sp.setBool(_kOnboarded, true);
-    _profile = p;
-    _onboarded = true;
+    await sp.setString(_kName, profile.name.trim());
+    await sp.setString(_kStartWeight, profile.startWeight.toString());
+    await sp.setString(_kUnit, profile.unit.storageKey);
+    final photoPath = profile.photoPath;
+    if (photoPath != null && photoPath.isNotEmpty) {
+      await sp.setString(_kPhotoPath, photoPath);
+    } else {
+      await sp.remove(_kPhotoPath);
+    }
+
+    _profile = profile;
     _loaded = true;
     notifyListeners();
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   sqflite: ^2.3.3
   path_provider: ^2.1.4
   shared_preferences: ^2.5.3
-  image_picker: ^1.2.0
+  image_picker: ^1.1.1
   permission_handler: ^12.0.1
   camera: ^0.11.0
   table_calendar: ^3.1.2


### PR DESCRIPTION
## Summary
- replace the legacy profile model with a user profile that tracks name, start weight, unit, and optional photo
- persist profile details in SharedPreferences and block navigation until the setup form is valid
- rebuild the setup screen with validation, weight unit toggle, and camera/gallery photo picker while keeping existing theming
- simplify the calendar header now that dialysis weekday flags are no longer collected
- align the image_picker dependency with the required version

## Testing
- Unable to run tests (Flutter SDK is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d9b3207f08832b950ebab636b81d45